### PR TITLE
feat: add run.sh with non-interactive mode support

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -5,12 +5,17 @@ JOURNAL=journal/$(ls -t journal/ | head -n 1)
 
 # Parse arguments
 DRY_RUN=false
+INTERACTIVE=true
 PROMPT="continue\n\nHere is today's journal: $JOURNAL"
 
 while [[ $# -gt 0 ]]; do
     case $1 in
         --dry-run)
             DRY_RUN=true
+            shift
+            ;;
+        --non-interactive)
+            INTERACTIVE=false
             shift
             ;;
         *)
@@ -54,6 +59,10 @@ if [ "$DRY_RUN" = true ]; then
     # In dry-run mode, just print the prompts
     echo -e "$PROMPT\n\n$FULL_PROMPT"
 else
-    # Normal mode: run gptme without printing prompts
-    gptme "$PROMPT" "$FULL_PROMPT"
+    # Normal mode: run gptme with or without interactive mode
+    if [ "$INTERACTIVE" = false ]; then
+        gptme --non-interactive "$PROMPT" "$FULL_PROMPT"
+    else
+        gptme "$PROMPT" "$FULL_PROMPT"
+    fi
 fi


### PR DESCRIPTION
Useful for certain workflows. Maybe we should just allow the user to pass the same arguments that gptme accepts to `run.sh`?
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add non-interactive mode to `run.sh` with `--non-interactive` argument, modifying `gptme` call accordingly.
> 
>   - **Behavior**:
>     - Add `--non-interactive` argument to `run.sh` to support non-interactive mode.
>     - Modify `run.sh` to call `gptme` with `--non-interactive` if the argument is provided.
>   - **Misc**:
>     - Update `run.sh` to handle new argument and adjust `gptme` call accordingly.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ErikBjare%2Fgptme-agent-template&utm_source=github&utm_medium=referral)<sup> for 9c24fdcbf60b0f2abea6afcc0bcabc548fd0c362. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->