### PR TITLE
fix: remove failing realpath usage

### DIFF
--- a/fork.sh
+++ b/fork.sh
@@ -182,9 +182,12 @@ command -v pre-commit > /dev/null && (cd "${TARGET_DIR}" && pre-commit install)
 # Dry run the agent to check for errors
 (cd "${TARGET_DIR}" && ./run.sh --dry-run > /dev/null)
 
+# Make the target directory relative to the current directory (prettier output)
+TARGET_DIR_RELATIVE=$(python3 -c "import os, sys; print(os.path.relpath('${TARGET_DIR}', start='$(pwd)'))")
+
 echo "
 Agent workspace created successfully! Next steps:
-1. cd ${TARGET_DIR}
+1. cd ${TARGET_DIR_RELATIVE}
 2. Start the agent with: ./run.sh
 3. The agent will guide you through the setup interview
 4. Follow the agent's instructions to establish its identity

--- a/fork.sh
+++ b/fork.sh
@@ -182,11 +182,9 @@ command -v pre-commit > /dev/null && (cd "${TARGET_DIR}" && pre-commit install)
 # Dry run the agent to check for errors
 (cd "${TARGET_DIR}" && ./run.sh --dry-run > /dev/null)
 
-TARGET_DIR_RELATIVE="./$(realpath --relative-to=$(pwd) ${TARGET_DIR})"
-
 echo "
 Agent workspace created successfully! Next steps:
-1. cd ${TARGET_DIR_RELATIVE}
+1. cd ${TARGET_DIR}
 2. Start the agent with: ./run.sh
 3. The agent will guide you through the setup interview
 4. Follow the agent's instructions to establish its identity


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Removes `realpath` usage in `fork.sh` and updates user instructions to use `TARGET_DIR` directly.
> 
>   - **Behavior**:
>     - Removes `realpath` usage in `fork.sh` for determining `TARGET_DIR` relative path.
>     - Updates user instructions to use `TARGET_DIR` directly instead of a relative path.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ErikBjare%2Fgptme-agent-template&utm_source=github&utm_medium=referral)<sup> for 83527f56cca60891fe322c4d4930a55fd47c6658. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->