### PR TITLE
fixed erroneous linking command

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -73,7 +73,7 @@ The task system is designed to help track and manage work effectively across ses
 
 1. **Creation**
    - Create new task file in tasks/all/
-   - Add symlink in tasks/new/: `ln -s ../all/taskname.md tasks/new/`
+   - Add symlink in tasks/new/: `ln -s all/taskname.md tasks/new/`
    - Add to TASKS.md with 🆕 status
    - CURRENT_TASK.md remains linked to no-active-task.md
 


### PR DESCRIPTION
If I look in the rest of this file it seems like the `all` folder should be amongst the other categories, correct? Then I think it makes more sense for also this link to be within the repo. Or am I missing something?
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes symlink command path in `ARCHITECTURE.md` for task creation.
> 
>   - **Documentation**:
>     - Fixes symlink command in `ARCHITECTURE.md` under Task Creation section.
>     - Changes `ln -s ../all/taskname.md tasks/new/` to `ln -s all/taskname.md tasks/new/` to correct the path.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ErikBjare%2Fgptme-agent-template&utm_source=github&utm_medium=referral)<sup> for c661ff0f4716feacda46936351308dfe9145c908. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->