### PR TITLE
docs: add content layers guide and fix people/ template

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -81,24 +81,47 @@ The people directory stores long-term information about individuals the agent in
 
 ## Content Layers
 
-Agent workspaces can include shared content via git submodules. Each layer has a different scope and audience — knowing where information belongs prevents duplication and staleness.
+Agent workspaces include shared content via git submodules. Each layer has a different scope — knowing where information belongs prevents duplication and staleness.
 
-| Layer | Repo | Scope | Content | Audience |
-|-------|------|-------|---------|----------|
-| **Public shared** | gptme-contrib | All gptme users | Packages, plugins, lessons, scripts | Open source community |
-| **Agent template** | gptme-agent-template | New agents | Workspace structure, templates, default configs | Agents at creation time |
-| **Org shared** | (e.g. gptme-superuser) | All org agents | Strategy, people, operations, processes | Internal team |
-| **Agent workspace** | (this repo) | Single agent | Identity, journals, tasks, knowledge | The agent itself |
+| Layer | Repo | Scope | Content |
+|-------|------|-------|---------|
+| **Agent template** | gptme-agent-template | All agents | Workspace structure, scripts, configs, templates |
+| **Public shared** | gptme-contrib | All gptme users | Packages, plugins, lessons, pre-commit hooks |
+| **Org shared** | (e.g. gptme-superuser) | Org agents | Strategy, people, operations, processes |
+| **Agent workspace** | (this repo) | Single agent | Identity, journals, tasks, knowledge |
+
+### Template and contrib relationship
+
+Most files in the agent template should be **symlinks into gptme-contrib** — this way agents get updates by simply updating the contrib submodule. Examples: pre-commit hooks, lesson files, shared scripts, validators.
+
+Some files **cannot be symlinks** because they are agent-specific or need local customization: `ABOUT.md`, `gptme.toml`, `README.md`, task/journal content.
+
+The rule of thumb: if the content is generic and useful across agents, it should live in contrib with the template symlinking to it. If it's workspace structure or identity, it lives in the template directly.
+
+### Staying current with the template
+
+Agents forked from this template will drift over time as the template evolves. To check what's changed:
+
+```sh
+# Add template as a remote (one-time)
+git remote add template https://github.com/gptme/gptme-agent-template.git
+
+# Fetch and diff against current template
+git fetch template master
+git diff HEAD...template/master -- ARCHITECTURE.md scripts/ .pre-commit-config.yaml
+```
+
+For contrib, agents using symlinks get updates automatically when the submodule is bumped. Check for broken or missing symlinks with: `find . -xtype l` (finds broken symlinks).
 
 ### Where does new content go?
 
+- **Should new agents start with it?** → agent template (symlink to contrib if generic)
 - **Is it useful to all gptme users?** → contrib (package, lesson, or script)
-- **Should new agents start with it?** → agent template
 - **Is it org-level context shared across agents?** → org repo (as submodule)
 - **Is it specific to this agent?** → agent workspace
 
 ### When to upstream
 
-- If you build a script that other agents could use → propose for contrib or org repo
-- If you establish a pattern that should be the default for new agents → propose for the template
+- If you build a script/lesson that other agents could use → propose for contrib
+- If you establish a structural pattern that should be the default → propose for the template
 - Org-level docs should contain long-term content only; volatile details stay in agent workspaces

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -55,7 +55,7 @@ The knowledge base stores long-term information and documentation.
 
 ## People Directory
 
-The people directory stores information about individuals the agent interacts with.
+The people directory stores long-term information about individuals the agent interacts with.
 
 ### Structure
 
@@ -68,25 +68,37 @@ The people directory stores information about individuals the agent interacts wi
   - Contact details
   - Interests and skills
   - Project collaborations
-  - Notes and history
+  - Notes
   - Preferences
-  - TODOs and action items
 
 ### Best Practices
 
-1. **Privacy**
+1. **Long-term content only** — profiles should contain stable information (identity, role, skills, preferences). Volatile details (current tasks, session counts, interaction timestamps) belong in journals or task files.
 
-   - Respect privacy preferences
-   - Only include publicly available information
-   - Maintain appropriate level of detail
+2. **Privacy** — respect privacy preferences, only include publicly available information, maintain appropriate level of detail.
 
-2. **Updates**
+3. **Organization** — use consistent formatting via templates, cross-reference with projects and tasks, link to relevant knowledge base entries.
 
-   - Keep interaction history current
-   - Update project collaborations
-   - Maintain active TODO lists
+## Content Layers
 
-3. **Organization**
-   - Use consistent formatting via templates
-   - Cross-reference with projects and tasks
-   - Link to relevant knowledge base entries
+Agent workspaces can include shared content via git submodules. Each layer has a different scope and audience — knowing where information belongs prevents duplication and staleness.
+
+| Layer | Repo | Scope | Content | Audience |
+|-------|------|-------|---------|----------|
+| **Public shared** | gptme-contrib | All gptme users | Packages, plugins, lessons, scripts | Open source community |
+| **Agent template** | gptme-agent-template | New agents | Workspace structure, templates, default configs | Agents at creation time |
+| **Org shared** | (e.g. gptme-superuser) | All org agents | Strategy, people, operations, processes | Internal team |
+| **Agent workspace** | (this repo) | Single agent | Identity, journals, tasks, knowledge | The agent itself |
+
+### Where does new content go?
+
+- **Is it useful to all gptme users?** → contrib (package, lesson, or script)
+- **Should new agents start with it?** → agent template
+- **Is it org-level context shared across agents?** → org repo (as submodule)
+- **Is it specific to this agent?** → agent workspace
+
+### When to upstream
+
+- If you build a script that other agents could use → propose for contrib or org repo
+- If you establish a pattern that should be the default for new agents → propose for the template
+- Org-level docs should contain long-term content only; volatile details stay in agent workspaces

--- a/people/templates/person.md
+++ b/people/templates/person.md
@@ -1,10 +1,15 @@
 # Person Profile Template
 
+<!--
+Profiles should contain long-term content: identity, role, skills, preferences.
+Avoid volatile details (current tasks, session counts, interaction timestamps).
+Those belong in journals or task files where they stay current naturally.
+-->
+
 ## Basic Information
 - Name:
-- Relationship to gptme-agent:
-- First interaction:
-- Last interaction:
+- Relationship:
+- Role/context:
 
 ## Contact Information
 - GitHub:
@@ -18,13 +23,10 @@
 ## Projects & Collaborations
 -
 
-## Notes & History
+## Notes
 -
 
 ## Preferences
 - Communication style:
 - Working style:
 - Technical preferences:
-
-## TODOs & Action Items
-- [ ]


### PR DESCRIPTION
## Summary
- Add a **Content Layers** section to ARCHITECTURE.md explaining the four layers of shared content (contrib → template → org repo → agent workspace) and where new information belongs
- Update `people/templates/person.md` to remove volatile fields (last interaction, TODOs) and add a long-term content principle
- Update people/ best practices to match

## Motivation
When agents create scripts, docs, or patterns, there's no guidance on whether to keep them local or upstream them. This leads to duplication and staleness (e.g. trade counts in org-level profiles that go stale in days).

The content layers table gives agents a clear decision framework:
- **Public shared** (contrib): packages, plugins, lessons — useful to all gptme users
- **Agent template**: workspace structure, default configs — what new agents start with
- **Org shared** (e.g. superuser): strategy, people, operations — internal team context
- **Agent workspace**: identity, journals, tasks — specific to one agent

## Test plan
- [ ] Verify content renders correctly in ARCHITECTURE.md
- [ ] Verify person.md template is usable for new profiles