### PR TITLE
fix(build): use prek as preferred hook runner, fall back to pre-commit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,21 +3,24 @@
 # to fix `git grep` for users with PAGER set
 PAGER=cat
 
+# Use prek (faster Rust-based runner) if available, fall back to pre-commit
+PRE_COMMIT := $(shell command -v prek 2>/dev/null || echo pre-commit)
+
 install: install-precommit  ## Install all hooks and dependencies
 
 install-precommit:  ## Install pre-commit hooks for repo
-	pre-commit install
+	$(PRE_COMMIT) install
 
 install-dotfiles:  ## Install dotfiles for user, with global git hooks
 	./dotfiles/install.sh
 
 format:  ## Fix formatting (ruff)
-	pre-commit run ruff-format --all-files || true
-	pre-commit run end-of-file-fixer --all-files || true
-	pre-commit run trailing-whitespace --all-files || true
+	$(PRE_COMMIT) run ruff-format --all-files || true
+	$(PRE_COMMIT) run end-of-file-fixer --all-files || true
+	$(PRE_COMMIT) run trailing-whitespace --all-files || true
 
 check:  ## Run all pre-commit hooks
-	pre-commit run --all-files
+	$(PRE_COMMIT) run --all-files
 
 test:  ## Run tests (if any exist)
 	@if [ -d tests ] && find tests -name '*.py' -not -name '__*' | grep -q .; then \
@@ -27,7 +30,7 @@ test:  ## Run tests (if any exist)
 	fi
 
 typecheck:  ## Run type checking (mypy)
-	pre-commit run mypy --all-files
+	$(PRE_COMMIT) run mypy --all-files
 
 context:  ## Generate context summary
 	./scripts/context.sh

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Before forking or using this template, ensure you have the required dependencies
 | `tree` | Directory visualization | `apt/brew/dnf install tree` |
 | `jq` | JSON processing | `apt/brew/dnf install jq` |
 | `gh` | GitHub CLI | [cli.github.com](https://cli.github.com/) |
-| `pre-commit` | Git hooks | `pipx install pre-commit` |
+| `prek` | Git hooks (fast Rust runner) | `uv tool install prek` |
 | `shellcheck` | Shell script linter | `apt/brew/dnf install shellcheck` |
 <!--/template-->
 

--- a/scripts/fork.sh
+++ b/scripts/fork.sh
@@ -352,18 +352,21 @@ else
     echo "Install with: uv tool install git+https://github.com/gptme/gptme-contrib#subdirectory=packages/gptodo"
 fi
 
-# If pre-commit is installed
-# Install pre-commit hooks (may fail if core.hooksPath is set)
-# shellcheck disable=SC2015  # A && B || C is intentional: ignore install failure
-command -v pre-commit > /dev/null && (cd "${TARGET_DIR}" && pre-commit install) || true
+# Prefer prek (faster Rust-based runner), fall back to pre-commit
+PRE_COMMIT_BIN=$(command -v prek 2>/dev/null || command -v pre-commit 2>/dev/null || true)
 
-# Stage files first, then run pre-commit to format them
+# Install pre-commit hooks if a hook runner is available
+# (may fail if core.hooksPath is set — that's fine, hooks still run via global config)
+# shellcheck disable=SC2015  # A && B || C is intentional: ignore install failure
+[ -n "$PRE_COMMIT_BIN" ] && (cd "${TARGET_DIR}" && "$PRE_COMMIT_BIN" install) || true
+
+# Stage files first, then run hook runner to format them
 (cd "${TARGET_DIR}" && git add .)
 
-# Run pre-commit to format staged files, then restage any changes
-if command -v pre-commit > /dev/null; then
-    # shellcheck disable=SC2015  # pre-commit run failures are intentionally swallowed
-    (cd "${TARGET_DIR}" && pre-commit run || true)
+# Run hook runner to format staged files, then restage any changes
+if [ -n "$PRE_COMMIT_BIN" ]; then
+    # shellcheck disable=SC2015  # hook runner failures are intentionally swallowed
+    (cd "${TARGET_DIR}" && "$PRE_COMMIT_BIN" run || true)
     (cd "${TARGET_DIR}" && git add .)
 fi
 

--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -136,10 +136,12 @@ case $OS in
         ;;
 esac
 
-if ! check_cmd "pre-commit" "pre-commit" "pipx install pre-commit"; then
+# prek is a faster Rust-based drop-in for pre-commit (preferred)
+# Falls back gracefully to pre-commit if prek isn't available
+if ! check_cmd "prek" "prek" "uv tool install prek"; then
     if $INSTALL_MODE; then
-        echo -e "${YELLOW}Installing pre-commit...${NC}"
-        pipx install pre-commit
+        echo -e "${YELLOW}Installing prek (fast pre-commit runner)...${NC}"
+        uv tool install prek
     fi
 fi
 

--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -137,8 +137,17 @@ case $OS in
 esac
 
 # prek is a faster Rust-based drop-in for pre-commit (preferred)
-# Falls back gracefully to pre-commit if prek isn't available
-if ! check_cmd "prek" "prek" "uv tool install prek"; then
+# Either prek or pre-commit satisfies this requirement; only flag MISSING if neither is available
+if command -v prek &> /dev/null; then
+    version=$(prek --version 2>/dev/null | head -1 || echo "installed")
+    echo -e "${GREEN}✓${NC} prek: $version"
+elif command -v pre-commit &> /dev/null; then
+    version=$(pre-commit --version 2>/dev/null | head -1 || echo "installed")
+    echo -e "${GREEN}✓${NC} pre-commit: $version (prek preferred: uv tool install prek)"
+else
+    echo -e "${RED}✗${NC} prek/pre-commit: not found"
+    echo -e "  ${YELLOW}→ uv tool install prek${NC}"
+    MISSING+=("prek")
     if $INSTALL_MODE; then
         echo -e "${YELLOW}Installing prek (fast pre-commit runner)...${NC}"
         uv tool install prek

--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -147,7 +147,7 @@ elif command -v pre-commit &> /dev/null; then
 else
     echo -e "${RED}✗${NC} prek/pre-commit: not found"
     echo -e "  ${YELLOW}→ uv tool install prek${NC}"
-    MISSING+=("prek")
+    MISSING+=("prek/pre-commit")
     if $INSTALL_MODE; then
         echo -e "${YELLOW}Installing prek (fast pre-commit runner)...${NC}"
         uv tool install prek


### PR DESCRIPTION
## Summary

- Replace hardcoded `pre-commit` in Makefile with `$(PRE_COMMIT)` variable that auto-detects `prek` (faster) and falls back to `pre-commit` if not installed
- Update README recommended dependencies to list `prek` with `uv tool install prek` as the installation method
- Update `install-deps.sh` to check for `prek` instead of `pre-commit`

## Why prek?

[prek](https://github.com/j178/prek) is a Rust-based drop-in replacement for `pre-commit` that:
- Uses the same `.pre-commit-config.yaml` config (zero migration cost)
- Is significantly faster (Rust vs Python startup)
- Installed via `uv tool install prek` (consistent with the `uv`-first toolchain we already use)

Bob's production workspace uses `prek` and the global `CLAUDE.md` recommends it. Aligning the template ensures new agents start with the faster setup.

## Test plan
- [ ] `make install` uses prek if available, pre-commit if not
- [ ] `make check` runs hooks correctly via the PRE_COMMIT variable
- [ ] `make format` still formats correctly