### PR TITLE
feat(skills): add skills/ directory and include gptme-contrib/skills in lessons dirs

### DIFF
--- a/gptme.toml
+++ b/gptme.toml
@@ -19,4 +19,5 @@ context_cmd = "scripts/context.sh"
 # The default ./lessons directory is automatically searched, so agent-specific lessons
 # are found first. Adding gptme-contrib/lessons provides shared lessons as fallback.
 # External skills (Anthropic SKILL.md format) are also crawled from these dirs.
-dirs = ["lessons", "gptme-contrib/lessons"]
+# The skills/ directory contains agent-specific skills (SKILL.md format executables).
+dirs = ["lessons", "skills", "gptme-contrib/lessons", "gptme-contrib/skills"]

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,63 @@
+# Skills Directory
+
+This directory contains **skills** — enhanced lessons that bundle workflows, scripts, and utilities for gptme agents.
+
+## Skills vs. Lessons
+
+| Feature | Lesson | Skill |
+|---------|--------|-------|
+| **Purpose** | Behavioral guidance | Executable workflows |
+| **Content** | Patterns, rules, examples | Instructions + bundled scripts |
+| **Activation** | Automatic via keywords | Explicit loading |
+| **Length** | 30-50 lines (primary) | Hundreds of lines |
+| **Scripts** | None | Bundled helper utilities |
+
+## Creating a Skill
+
+Skills use a `SKILL.md` file with YAML frontmatter:
+
+```markdown
+---
+name: my-skill
+description: What this skill does and when to use it
+---
+
+# My Skill
+
+## Overview
+...
+```
+
+### Directory structure
+
+```text
+skills/
+└── my-skill/
+    ├── SKILL.md        # Required: instructions + frontmatter
+    └── scripts/        # Optional: supporting scripts
+        └── helper.py
+```
+
+## Shared Skills (gptme-contrib)
+
+Additional shared skills are available in `gptme-contrib/skills/`:
+
+- `template-skill` — Starting point for creating new skills
+- `progressive-disclosure` — Pattern for progressive context loading
+- `code-review-helper` — Code review workflow
+- `artifact-publishing` — Publishing blog posts and content
+
+## Configuration
+
+Skills are automatically crawled by gptme when listed in `gptme.toml`:
+
+```toml
+[lessons]
+dirs = ["lessons", "skills", "gptme-contrib/lessons", "gptme-contrib/skills"]
+```
+
+## Related
+
+- [gptme-contrib/skills/](../gptme-contrib/skills/) — Shared skills
+- [lessons/README.md](../lessons/README.md) — Lesson system
+- [gptme skill marketplace](https://github.com/gptme/gptme/issues/1566) — Publishing skills


### PR DESCRIPTION
## Summary

- Adds a `skills/` directory for agent-specific SKILL.md-format executables
- Updates `gptme.toml` to crawl both `skills/` and `gptme-contrib/skills/`
- Includes `skills/README.md` documenting the skills system

## Motivation

The skills system was added to gptme (via #1566) but the agent template never scaffolded the `skills/` directory or configured `gptme.toml` to crawl it. New agents forked from the template couldn't discover shared skills from `gptme-contrib/skills/` (template-skill, code-review-helper, progressive-disclosure, etc.) without manual configuration.

## Changes

- `skills/README.md` — explains skills vs lessons, how to create skills, and what's available in gptme-contrib
- `gptme.toml` — updated `dirs` from `["lessons", "gptme-contrib/lessons"]` to `["lessons", "skills", "gptme-contrib/lessons", "gptme-contrib/skills"]`

## Test plan

- [ ] Fork a new agent from the template
- [ ] Verify `gptme-contrib/skills/` is crawled and skills are discoverable
- [ ] Verify adding a `skills/my-skill/SKILL.md` in the agent workspace is also picked up