### PR TITLE
docs(AGENTS.md): add nested Claude Code and cross-repo reference pitfalls

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -137,6 +137,8 @@ git push -u origin "$BRANCH"
 gh pr create
 ```
 
+### Cross-Repo GitHub References
+
 When writing GitHub issue/PR comments that reference issues in a **different** repo,
 always use the full `org/repo#N` format — GitHub auto-links bare `#N` to the
 *current* repo, making cross-repo references silently wrong:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,6 +95,32 @@ make typecheck   # Type checking
 - Run `scripts/context.sh` at session start for dynamic context (tasks, GitHub, git status)
 - No automatic lesson injection — check `lessons/` when relevant
 
+### Nested Claude Code Subprocesses
+
+Claude Code sets `CLAUDECODE` env var, which blocks nested `claude -p` invocations
+(protection against recursion). If your agent needs to spawn a Claude subprocess
+(e.g. from a script or systemd service), unset it first:
+
+```python
+import os, subprocess
+env = os.environ.copy()
+env.pop("CLAUDECODE", None)
+env.pop("CLAUDE_CODE_ENTRYPOINT", None)
+subprocess.run(["claude", "-p", prompt], env=env)
+```
+
+```bash
+# Shell equivalent
+env -u CLAUDECODE -u CLAUDE_CODE_ENTRYPOINT claude -p "prompt"
+```
+
+Also: when running `claude -p` inside tmux, always add `</dev/null` to prevent
+the process from receiving SIGSTOP (`T` state) when it tries to read stdin:
+
+```bash
+claude -p "prompt" </dev/null
+```
+
 ### Working on External Repos
 
 For any code change outside the workspace repo, use worktrees:
@@ -109,4 +135,17 @@ git branch --unset-upstream   # prevent accidental push to master
 # ... make changes, commit ...
 git push -u origin "$BRANCH"
 gh pr create
+```
+
+When writing GitHub issue/PR comments that reference issues in a **different** repo,
+always use the full `org/repo#N` format — GitHub auto-links bare `#N` to the
+*current* repo, making cross-repo references silently wrong:
+
+```markdown
+<!-- Wrong: links to current repo's issue #42 -->
+See #42 for context.
+
+<!-- Correct: links to the intended repo -->
+See gptme/gptme#42 for context.
+See https://github.com/gptme/gptme/issues/42 for context.
 ```


### PR DESCRIPTION
## Summary

Two operational patterns missing from the template that trip up agents regularly, derived from real incidents in Bob's autonomous runs.

### 1. Nested Claude Code Subprocesses

Claude Code sets a `CLAUDECODE` env var when active, which **blocks nested `claude -p` invocations** as a recursion guard. Agents that spawn Claude subprocesses (e.g. from systemd services, scripts, or task runners) need to unset this env var first.

Also documents the **tmux stdin issue**: `claude -p` inside tmux without `</dev/null` causes the process to receive `SIGSTOP` and hang in `T` (stopped) state.

### 2. Cross-Repo GitHub References

GitHub auto-links bare `#N` to the **current repo**, not the one you intend. Cross-repo references in comments/PRs must use `org/repo#N` or a full URL. Agents writing GitHub comments are prone to this since they process many repos.

## Motivation

These patterns were missing from the template but are documented in agent-specific `CLAUDE.md` files after being discovered the hard way. Adding them here means new agents forked from the template get this guidance automatically.