### PR TITLE
docs(lessons): add absolute-paths and git-commit-format workflow lessons

### DIFF
--- a/lessons/workflow/absolute-paths-for-workspace-files.md
+++ b/lessons/workflow/absolute-paths-for-workspace-files.md
@@ -1,0 +1,54 @@
+---
+match:
+  keywords:
+    - "save file to"
+    - "write journal entry"
+    - "mkdir -p journal"
+    - "file path"
+    - "wrong directory"
+    - "file ended up in wrong"
+    - "journal created in external repo"
+status: active
+---
+
+# Always Use Absolute Paths for Workspace Files
+
+## Rule
+Always use absolute paths when saving/appending to workspace files, especially journal entries.
+
+## Context
+When working across multiple repositories or when current directory might change during operation.
+
+## Detection
+- Files ending up in wrong directory (e.g., journal entry created in a checked-out external repo)
+- "File not found" errors when appending to a previously written file
+- Relative paths used with save/append tools
+- Journal entries created outside the agent workspace
+
+## Pattern
+```text
+# ❌ Wrong: relative path depends on cwd
+cd ~/projects/gptme
+echo "..." >> journal/2025-10-14-topic.md  # creates in wrong repo!
+
+# ✅ Correct: absolute path works from any directory
+WORKSPACE=$(git rev-parse --show-toplevel)
+echo "..." >> "$WORKSPACE/journal/2025-10-14-topic.md"
+```
+
+For tools that write files directly (save, append), always use the absolute path:
+```text
+# ❌ Wrong
+save journal/2025-10-14/session.md
+
+# ✅ Correct
+save /home/agent/workspace/journal/2025-10-14/session.md
+```
+
+## Outcome
+- **Reliability**: Works regardless of current working directory
+- **Prevents data loss**: Files always go to the intended location
+- **No confusion**: Explicit about which repo/workspace receives the file
+
+## Related
+- Full context: knowledge/lessons/workflow/absolute-paths-for-workspace-files.md

--- a/lessons/workflow/git-commit-format.md
+++ b/lessons/workflow/git-commit-format.md
@@ -1,0 +1,63 @@
+---
+match:
+  keywords:
+    - "conventional commits"
+    - "commit message format"
+    - "write commit message"
+    - "commit type prefix"
+    - "feat fix docs commit"
+status: active
+---
+
+# Git Commit Message Format
+
+## Rule
+All commit messages must follow Conventional Commits format with a type prefix, optional scope, and short description.
+
+## Context
+When creating git commits in any workspace or repository.
+
+## Detection
+Observable signals indicating incorrect commit format:
+- Commit message missing type prefix (feat, fix, docs, etc.)
+- Vague descriptions ("update code", "fix stuff", "wip")
+- Multiple unrelated changes in a single commit
+- Missing scope when it would add clarity
+
+## Pattern
+```text
+type(scope): short description
+
+Optional longer description explaining why,
+not just what changed.
+```
+
+**Common types**: `feat`, `fix`, `docs`, `style`, `refactor`, `test`, `chore`
+
+**Examples**:
+```text
+feat(auth): add JWT-based authentication
+fix(shell): preserve output when last line lacks trailing newline
+docs(lessons): add absolute-paths lesson
+refactor(context): migrate shell scripts to Python
+test(tasks): add integration tests for task state machine
+chore: update gptme-contrib submodule
+```
+
+**With scope** (preferred when the change is component-specific):
+```text
+fix(api): handle rate limit errors gracefully
+
+Add exponential backoff for 429 responses.
+Includes retry logic with configurable max attempts.
+```
+
+## Outcome
+Following this pattern ensures:
+- Automated versioning and changelog generation works correctly
+- Clear, scannable git history
+- Easy to identify the nature of a change at a glance
+- Consistent format across all repositories
+
+## Related
+- [Conventional Commits Specification](https://www.conventionalcommits.org/)


### PR DESCRIPTION
## Summary

Adds two workflow lessons to the template's `lessons/workflow/` directory, based on LOO (leave-one-out) effectiveness analysis from Bob's workspace:

- **`absolute-paths-for-workspace-files`** (Δ=+0.198 session reward, p<0.001): Always use absolute paths when writing workspace files. Prevents journal entries and other files from being created in the wrong directory when working across multiple repos.

- **`git-commit-format`** (Δ=+0.162 session reward, p<0.001): Conventional Commits format for all commit messages. Keeps git history clean and scannable.

Neither lesson is currently in `gptme-contrib/lessons/workflow/`, so new agents created from this template were missing both. The template's own `lessons/workflow/` directory was empty before this PR.

## Why these two?

From LOO effectiveness analysis (`scripts/lesson-loo-analysis.py --category-controlled`), these are the top two lessons by session reward improvement that are NOT already in gptme-contrib. Adding them to the template ensures every new agent benefits from day one.

## Test plan

- [x] Pre-commit hooks pass (lessons validated)
- [x] Lesson format matches `markdown-codeblock-syntax.md` style
- [x] Keywords are specific multi-word phrases (not single words)