### PR TITLE
docs: upstream multi-session safety, troubleshooting, and config examples

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,7 +38,8 @@ echo "entry" >> journal/2025-10-14/topic.md
 - **External repos**: Use branches + PRs from worktrees at `/tmp/worktrees/<repo>/<branch>/`
 - **Stage explicitly**: Use `git add <files>`, never `git add .` or `git commit -a`
 - **Multi-session safety**: If running concurrent sessions (autonomous + operator), use
-  `git safe-commit` (flock-based wrapper) to prevent prek stash/restore race conditions:
+  `git safe-commit` (flock-based wrapper in `bin/`) to prevent prek stash/restore race conditions.
+  Requires `bin/` in PATH (e.g. `export PATH="$PWD/bin:$PATH"` in `.envrc`):
   ```bash
   git safe-commit file1.py file2.py -m "feat: description"
   ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,11 @@ echo "entry" >> journal/2025-10-14/topic.md
 - **Workspace repo**: Commit directly to master for docs/journal/tasks
 - **External repos**: Use branches + PRs from worktrees at `/tmp/worktrees/<repo>/<branch>/`
 - **Stage explicitly**: Use `git add <files>`, never `git add .` or `git commit -a`
+- **Multi-session safety**: If running concurrent sessions (autonomous + operator), use
+  `git safe-commit` (flock-based wrapper) to prevent prek stash/restore race conditions:
+  ```bash
+  git safe-commit file1.py file2.py -m "feat: description"
+  ```
 - **PR merge strategy**: Always `--squash` when merging
 - **No AI attribution**: Never add `Co-Authored-By: Claude` or "Generated with Claude Code" to commits/PRs
 
@@ -63,6 +68,12 @@ echo "entry" >> journal/2025-10-14/topic.md
 ### Pre-Commit Hooks
 
 Run automatically on commit. Don't bypass with `--no-verify` unless explicitly asked.
+
+> **Important**: Always ensure gptme-contrib submodule is up to date before running hooks:
+> ```bash
+> git submodule update --init --recursive
+> ```
+> This prevents false positives in link checking for files referenced from `gptme-contrib/lessons/`.
 
 ```bash
 # Fix formatting
@@ -150,4 +161,55 @@ See #42 for context.
 <!-- Correct: links to the intended repo -->
 See gptme/gptme#42 for context.
 See https://github.com/gptme/gptme/issues/42 for context.
+```
+
+## Troubleshooting
+
+### Pre-Commit Hooks Failing
+
+```bash
+# Update submodule first (fixes false positive link errors)
+git submodule update --init --recursive
+
+# Fix formatting issues
+make format
+
+# Run all hooks to see what's failing
+make check
+
+# If mypy fails, check packages are installed
+uv sync --all-packages
+```
+
+### Import Errors
+
+```bash
+# Reinstall all workspace packages
+uv sync --all-packages
+
+# Verify package is installed
+uv pip list | grep <package-name>
+```
+
+### Context Script Slow or Failing
+
+```bash
+# Test context generation
+time ./scripts/context.sh > /dev/null
+
+# If failing, check dependencies
+which gptodo gh git
+```
+
+### gptme-contrib Submodule Issues
+
+```bash
+# Submodule not initialized
+git submodule update --init --recursive
+
+# Submodule out of date
+git submodule update --remote gptme-contrib
+
+# "core.bare" error in submodule
+git config --file .git/modules/gptme-contrib/config --unset core.bare
 ```

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,13 @@
-.PHONY: install-precommit install-dotfiles format check test typecheck context stats
+.PHONY: help install-precommit install-dotfiles format check test typecheck context stats
 
 # to fix `git grep` for users with PAGER set
 PAGER=cat
 
 # Use prek (faster Rust-based runner) if available, fall back to pre-commit
 PRE_COMMIT := $(shell command -v prek 2>/dev/null || echo pre-commit)
+
+help:  ## Show available targets
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
 
 install: install-precommit  ## Install all hooks and dependencies
 

--- a/bin/git-safe-commit
+++ b/bin/git-safe-commit
@@ -1,0 +1,30 @@
+#!/bin/bash
+# git-safe-commit: Serialize git commits to prevent concurrent staging conflicts
+#
+# Problem: When multiple sessions (autonomous, operator, meta-operator) run
+# concurrently on the same repo, they share .git/index. prek's stash/restore
+# cycle during pre-commit hooks can race with concurrent commits, causing:
+#   - Wrong files in commits (staged by another session)
+#   - prek stash-restore conflicts that silently revert edits
+#   - Wasted tokens re-doing work that was lost
+#
+# Solution: flock serializes the entire commit (including pre-commit hooks)
+# so prek's stash/restore is atomic from other sessions' perspective.
+#
+# Usage: git-safe-commit file1.py file2.py -m "feat: description"
+#        (same arguments as `git commit`)
+#
+# See: https://github.com/gptme/gptme-agent-template/issues/75
+
+set -uo pipefail
+
+GIT_DIR="$(git rev-parse --git-dir 2>/dev/null)" || true
+if [ -z "$GIT_DIR" ]; then
+    echo "error: not in a git repository" >&2
+    exit 1
+fi
+
+LOCKFILE="$GIT_DIR/commit.lock"
+
+# Serialize commits with 60s timeout (prek hooks can take ~30s)
+exec flock --timeout 60 "$LOCKFILE" git commit "$@"

--- a/gptme.toml
+++ b/gptme.toml
@@ -23,3 +23,22 @@ context_cmd = "scripts/context.sh"
 # External skills (Anthropic SKILL.md format) are crawled from all dirs.
 # First dir wins on filename collision, so agent-specific files take precedence.
 dirs = ["lessons", "skills", "gptme-contrib/lessons", "gptme-contrib/skills"]
+
+[plugins]
+# Plugin directories to search for custom plugins
+# paths = ["plugins"]
+# enabled = ["my_plugin"]
+
+[env]
+# Environment variables available to the agent
+# GPTME_TTS_VOICE = "am_adam"  # for Kokoro TTS
+# GPTME_LESSONS_TS_STATE = "state/lesson-thompson/bandit-state.json"
+
+# [mcp]
+# enabled = false
+# auto_start = false
+#
+# [[mcp.servers]]
+# name = "example-mcp-server"
+# command = "npx"
+# args = ["-y", "example-mcp-server"]


### PR DESCRIPTION
## Summary

- **Multi-session git safety**: Add `git safe-commit` pattern for concurrent session environments (flock-based wrapper prevents prek stash/restore race conditions)
- **Submodule prerequisite**: Add callout warning to update gptme-contrib before running pre-commit hooks (prevents false positive link errors)
- **Troubleshooting section**: Common issues with pre-commit hooks, import errors, context script, and submodule problems
- **Config examples**: Add commented `[plugins]`, `[env]`, and `[mcp]` sections to `gptme.toml` so agents can see what's available
- **`make help` target**: Lists all available Makefile targets with descriptions

All patterns upstreamed from Bob's production workspace (1700+ sessions).

## Test plan
- [x] Pre-commit hooks pass
- [ ] Verify `make help` output is formatted correctly
- [ ] Review troubleshooting steps against current gptme-contrib infrastructure