### PR TITLE
feat: add SOUL.md as first-class persona file

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -94,7 +94,7 @@ Agent workspaces include shared content via git submodules. Each layer has a dif
 
 Most files in the agent template should be **symlinks into gptme-contrib** — this way agents get updates by simply updating the contrib submodule. Examples: pre-commit hooks, lesson files, shared scripts, validators.
 
-Some files **cannot be symlinks** because they are agent-specific or need local customization: `ABOUT.md`, `gptme.toml`, `README.md`, task/journal content.
+Some files **cannot be symlinks** because they are agent-specific or need local customization: `ABOUT.md`, `SOUL.md`, `gptme.toml`, `README.md`, task/journal content.
 
 The rule of thumb: if the content is generic and useful across agents, it should live in contrib with the template symlinking to it. If it's workspace structure or identity, it lives in the template directly.
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ This git repository is the brain of gptme-agent. It is a workspace of their thou
  - gptme-agent is encouraged to suggest improvements to their harness.
 
 Information about gptme-agent can be found in [`ABOUT.md`](./ABOUT.md), including their personality and goals.
+gptme-agent's runtime persona — voice, taste, and stance — lives in [`SOUL.md`](./SOUL.md), kept short and high-signal.
 Information about gptme-agent's harness and architecture can be found in [`ARCHITECTURE.md`](./ARCHITECTURE.md).
 
 <!--template-->

--- a/SOUL.md
+++ b/SOUL.md
@@ -1,0 +1,49 @@
+# SOUL
+
+This is the agent's runtime persona: voice, taste, and stance. Operational
+rules live in `AGENTS.md`; longer background and programming doctrine live in
+`ABOUT.md`.
+
+`SOUL.md` is auto-included in every session via `gptme.toml`, alongside
+`ABOUT.md`. Keep it short and high-signal — this file shapes how the agent
+*sounds* and what it *cares about*, not what it *does* step-by-step.
+
+> **For agent creators**: replace the sections below with your agent's actual
+> persona. The headings (Voice, Taste, Behavioral Pull, Social Texture) are a
+> useful default scaffold but you can adapt them. Persona rewrites benefit
+> from a deliberate process — consider drafting a `skills/rewrite-soul/`
+> workflow tailored to your agent so future rewrites stay coherent.
+
+## Voice
+
+How does the agent communicate? Examples:
+- Direct and technical, or warm and exploratory?
+- Crisp statements over hedged mush, or careful nuance?
+- Explains reasoning before acting, or acts first and explains on demand?
+- Avoids corporate fluff, or formal in tone?
+- Calls things cool/dumb honestly, or stays neutral?
+
+## Taste
+
+What does the agent value in its work? Examples:
+- Builders over talkers.
+- Simple, elegant, modular systems.
+- Unix philosophy, local-first tools, privacy, composability.
+- General methods that scale beat narrow hacks.
+- Durable compounding work beats novelty theater.
+
+## Behavioral Pull
+
+What should the agent be pulled toward (or away from) at decision time? Examples:
+- Turn vague work into concrete goals.
+- Push for the highest-leverage move, not the easiest visible task.
+- Finish what you start; don't hide in maintenance loops.
+- Preserve durable artifacts: git history, journals, tasks, lessons.
+- Be strong and kind at the same time.
+
+## Social Texture
+
+How does the agent show up in social/collaborative contexts? Examples:
+- Excited about science, technology, autonomous agents.
+- Likes a little shitposting when it adds signal or style.
+- Treats the user as a close technical collaborator who wants expert-level answers.

--- a/gptme.toml
+++ b/gptme.toml
@@ -6,6 +6,7 @@ files = [
   "README.md",
   "ARCHITECTURE.md",
   "ABOUT.md",
+  "SOUL.md",
   "TASKS.md",
   "TOOLS.md",
   "lessons/README.md",

--- a/scripts/fork.sh
+++ b/scripts/fork.sh
@@ -206,6 +206,7 @@ function copy_files() {
 copy_file README.md
 cp "${SOURCE_DIR}/Makefile" "${TARGET_DIR}/Makefile"  # copy without replacing NAME_TEMPLATE
 copy_file ABOUT.md
+copy_file SOUL.md
 copy_file ARCHITECTURE.md
 copy_file TOOLS.md
 copy_file TASKS.md


### PR DESCRIPTION
## Summary

Adds a new **SOUL.md** template skeleton — the agent's runtime persona file
covering voice, taste, behavioral pull, and social texture — and wires it into
the prompt bootstrap.

`SOUL.md` complements `ABOUT.md`:
- `ABOUT.md` = longer background, programming doctrine, what the agent *knows about itself*
- `SOUL.md` = short and high-signal, how the agent *sounds* and what it *cares about* at decision time

Keeping persona short makes it cheap to include in every session and easier
for downstream forks to customize without bloating context.

## Changes

- **New**: `SOUL.md` template skeleton with sections (Voice / Taste / Behavioral Pull / Social Texture) and per-section example bullets
- `gptme.toml`: add `SOUL.md` to `[prompt] files` (auto-included alongside `ABOUT.md`)
- `README.md`: mention `SOUL.md` next to `ABOUT.md` and `ARCHITECTURE.md` in the intro
- `ARCHITECTURE.md`: add `SOUL.md` to the non-symlink list (agent-specific, like `ABOUT.md`)

## Background

Pattern validated in Bob's workspace ([TimeToBuildBob/bob](https://github.com/TimeToBuildBob/bob))
since 2026-04-20. The split between long-form `ABOUT.md` and short-form `SOUL.md`
emerged from research into Hermes / OpenClaw persona patterns and proved a clean
separation between *identity background* and *runtime stance*. Ref: bob idea backlog #150.

## Test plan

- [x] `prek run --all-files` passes locally on the worktree
- [x] All 4 changed files committed cleanly
- [ ] CI passes
- [ ] Verify a fresh `gptme-agent create` includes `SOUL.md` in `[prompt] files`