### PR TITLE
feat(lessons): add 3 upstream lessons from bob workspace

### DIFF
--- a/lessons/tools/gh-body-heredoc-not-quotes.md
+++ b/lessons/tools/gh-body-heredoc-not-quotes.md
@@ -1,0 +1,57 @@
+---
+match:
+  keywords:
+    - "gh pr comment --body"
+    - "gh issue comment --body"
+    - "backtick in body"
+    - "comment body mangled"
+    - "github comment stripped"
+    - "gh pr comment"
+    - "gh issue comment"
+    - "gh pr create"
+  session_categories: [social, cross-repo, code]
+description: "A posted gh comment or PR body is missing its backtick code spans (version names, code) because backticks inside a double-quoted --body were interpreted as command substitution"
+status: active
+---
+
+# Use Heredoc (not quotes) for gh --body with backticks
+
+## Rule
+When the `--body` text contains backticks, use a heredoc or `$'...'` syntax — never
+double-quoted strings — or bash will interpret backticks as command substitution
+and silently strip the content.
+
+## Context
+Whenever posting GitHub comments, PR descriptions, or review replies via `gh`
+that include Markdown inline code (backtick-wrapped text like `ubuntu-20.04`).
+
+## Detection
+- About to write `gh ... --body "... \`code\` ..."` with backticks inside double quotes
+- Posted a comment and the version names / code spans are missing from the result
+- Shell emits "command not found" stderr lines for the backtick content
+
+## Pattern
+```bash
+# ❌ Wrong: bash interprets backticks as command substitution
+gh pr comment 156 --repo owner/repo \
+  --body "Yes, `ubuntu-20.04` runners are gone. Use `ubuntu-22.04`."
+# → stderr: bash: ubuntu-20.04: command not found
+# → comment posted as: "Yes,  runners are gone. Use ."
+
+# ✅ Correct: heredoc preserves backticks literally
+gh pr comment 156 --repo owner/repo --body "$(cat <<'EOF'
+Yes, `ubuntu-20.04` runners are gone. Use `ubuntu-22.04`.
+EOF
+)"
+
+# ✅ Also correct: $'...' with escaped backticks
+gh pr comment 156 --body $'Yes, `ubuntu-20.04` runners are gone.'
+```
+
+## Outcome
+- GitHub comment posts with the exact Markdown the reader expects
+- No silent stripping of code spans from public-facing text
+- No confusing "command not found" stderr noise
+
+## Related
+- [shell-heredoc.md](./shell-heredoc.md) — avoid heredoc in gptme shell tool; use `$(cat <<'EOF'...)` in Bash scripts

--- a/lessons/tools/inline-python-bash-silent-syntax-error.md
+++ b/lessons/tools/inline-python-bash-silent-syntax-error.md
@@ -1,0 +1,71 @@
+---
+match:
+  keywords:
+    - "stderr swallowed around python3 -c"
+    - "shell wrapper hid python syntaxerror"
+    - "multi-line inline python drift"
+    - "2>/dev/null python"
+    - "inline python syntax"
+  session_categories: [code, infrastructure]
+description: "Inline python3 -c or heredoc Python in a shell script is piped to 2>/dev/null || true, so a SyntaxError fails silently and an expected field/file/commit never gets written"
+status: active
+---
+
+# Inline Python in Bash Hides SyntaxErrors
+
+## Rule
+Don't pipe inline `python3 -c "..."` to `2>/dev/null || true`. Either let stderr
+surface, or extract the script to a separate `.py` file so syntax errors fail
+loudly the first time the script runs.
+
+## Context
+When embedding multi-line Python inside shell scripts (hooks, systemd ExecStart
+wrappers, post-processing pipelines). Bash heredocs and `python3 -c` blocks
+easily acquire indentation drift on edit, and the surrounding `2>/dev/null` +
+`|| true` pattern swallows the resulting `SyntaxError`.
+
+## Detection
+- Inline `python3 -c '...'` or `python3 << EOF` blocks that suppress stderr
+- `|| true` immediately after a python invocation
+- A field, file, or commit that "should have" been written but wasn't, with no error visible
+- **`@Q`/`${var}` interpolated into an *unquoted* heredoc body** (`json.loads(${item_json@Q})`):
+  `@Q` emits a bash `$'...'` C-string when the value holds an apostrophe or newline — invalid Python.
+  A title like `Erik's fix` then SyntaxErrors silently.
+
+## Pattern
+```bash
+# ❌ Wrong — SyntaxError silently ignored, data never written
+python3 -c "
+for rec in records:
+    if changed:    # mis-indented; SyntaxError
+        update(rec)
+        break
+" 2>/dev/null || true
+
+# ✅ Correct — extract to a real script file, let errors surface
+python3 scripts/your_backfill.py "$session_id" || \
+    echo "WARN: backfill failed for $session_id" >&2
+
+# ✅ Also correct — keep inline but don't swallow stderr
+python3 -c "
+for rec in records:
+    if changed:
+        update(rec)
+        break
+"
+
+# ✅ Passing values into a heredoc — quote the delimiter + use os.environ,
+#    never interpolate bash (@Q / ${var}) into the Python body
+out=$(ITEM_JSON="$item_json" python3 - <<'PY'
+import json, os
+print(json.loads(os.environ["ITEM_JSON"]))
+PY
+)
+```
+
+## Outcome
+- SyntaxErrors fail on the first run instead of after N days of silent data loss
+- Inline Python becomes a deliberate choice, not a default that hides bugs
+
+## Related
+- [markdown-codeblock-syntax.md](./markdown-codeblock-syntax.md) — similar silent-failure pattern with markdown code fences

--- a/lessons/tools/shell-variable-syntax.md
+++ b/lessons/tools/shell-variable-syntax.md
@@ -1,0 +1,54 @@
+---
+match:
+  keywords:
+    - "missing dollar sign in shell"
+    - "bare variable in shell"
+    - "forgot the dollar prefix"
+    - "command not found variable"
+  session_categories: [code, infrastructure]
+description: "A shell command fails with 'VARIABLE_NAME: command not found' because a variable was referenced as a bare word without the $ prefix"
+status: active
+---
+
+# Shell Variable Syntax
+
+## Rule
+Always use `$` prefix when referencing variables in shell commands.
+
+## Context
+When constructing shell commands programmatically or writing shell scripts.
+
+## Detection
+Observable signals indicating missing `$` prefix:
+- Error: `bash: VARIABLE_NAME: command not found`
+- Variable names appearing as bare words in commands
+- All-caps identifiers used as commands (e.g. `TIMEOUT: command not found`)
+- A numeric literal treated as a command (`300.0: command not found`)
+
+## Pattern
+```shell
+# ❌ Wrong: bare variable name — bash tries to run it as a command
+REPO_ROOT
+
+# ✅ Correct: with $ prefix
+echo $REPO_ROOT
+
+# ❌ Wrong: numeric literal as command
+300.0
+
+# ✅ Correct: use in proper context
+timeout 300 mycommand
+
+# ❌ Wrong: variable inside assignment with missing $ on the right
+DEST=HOME/projects    # HOME never expanded
+
+# ✅ Correct
+DEST=$HOME/projects
+```
+
+## Outcome
+- No spurious "command not found" errors from bare variable names
+- Shell scripts run predictably without hidden expansion failures
+
+## Related
+- [shell-heredoc.md](./shell-heredoc.md) — other common shell trap in gptme agent scripts


### PR DESCRIPTION
## Summary

Syncs the top 3 template-ready lessons identified by `lesson-sync-checker.py` in the bob agent workspace. All three are gptme-agnostic shell/Python patterns that apply to any agent built from this template.

**Lessons added:**

- **`tools/gh-body-heredoc-not-quotes`**: When `gh --body` text contains backticks, double-quoted strings cause bash to interpret them as command substitution, silently stripping Markdown code spans from posted comments. Use a heredoc instead.

- **`tools/inline-python-bash-silent-syntax-error`**: Piping `python3 -c "..."` to `2>/dev/null || true` swallows `SyntaxError` so data never gets written and no error is visible. Extract to a `.py` file or drop the suppression.

- **`tools/shell-variable-syntax`**: Referencing a shell variable without the `$` prefix causes bash to try to run it as a command (`VARIABLE_NAME: command not found`). Always use `$VAR`.

## How these were selected

`scripts/lesson-sync-checker.py` in the bob workspace scores lessons by `generality × category weight` and identifies lessons not yet in the template or gptme-contrib. These three scored 1.00 (highest) and contain no Bob-specific paths or infrastructure references.

## Test plan

- [ ] Lessons render correctly in the template context
- [ ] Keywords are specific enough to avoid false positive injection
- [ ] No Bob-specific paths, packages, or repo references remain