### PR TITLE
feat(lessons): upstream 5 generic tool lessons (batch 2)

### DIFF
--- a/lessons/tools/curl-script-flags.md
+++ b/lessons/tools/curl-script-flags.md
@@ -1,0 +1,58 @@
+---
+match:
+  session_categories: [code, infrastructure, monitoring]
+  keywords:
+    - "curl in script"
+    - "curl -s http"
+    - "curl -fsSL"
+    - "silent curl failure"
+    - "health check curl"
+description: "Use curl -fsSL instead of bare curl in scripts and health checks so silent HTTP failures surface as errors"
+status: active
+---
+
+# curl Script Flags
+
+## Rule
+In scripts and health checks, always use `curl -fsSL` instead of bare `curl`.
+
+## Context
+When using `curl` in shell scripts, automation, or health checks. The default `curl` behavior treats HTTP errors (4xx, 5xx) as success — it only fails on transport-level errors (DNS, connection refused, timeout).
+
+## Detection
+- `curl https://api.example.com | jq ...` without `-f`
+- Health checks using `curl -s http://...` that pass on 404/500
+- Scripts checking `$?` after curl and assuming HTTP 200
+- `curl -I` or `curl -sI` for status checks without `-f`
+
+## Pattern
+```bash
+# ❌ Wrong: HTTP 404 returns exit 0
+response=$(curl -s "https://api.example.com/health")
+# $response might be {"error": "not found"} but script continues
+
+# ✅ Correct: fail on HTTP errors, silent output, follow redirects
+response=$(curl -fsSL "https://api.example.com/health")
+# HTTP 4xx/5xx → exit non-zero → script stops or enters error handler
+
+# ✅ For header-only status checks
+if curl -fsSLI "https://example.com" >/dev/null 2>&1; then
+    echo "OK"
+else
+    echo "FAIL"
+fi
+```
+
+Flag reference:
+- `-f` / `--fail`: return non-zero on HTTP 4xx/5xx
+- `-s` / `--silent`: suppress progress meter
+- `-S` / `--show-error`: show error text even with `-s`
+- `-L` / `--location`: follow redirects
+
+## Outcome
+- Scripts fail fast on HTTP errors instead of processing garbage data
+- Health checks correctly detect degraded services
+- CI pipelines catch API failures instead of silently passing
+
+## Related
+- [exit-code-127-use-uv-run.md](./exit-code-127-use-uv-run.md) — another silent failure class in scripts

--- a/lessons/tools/exit-code-127-use-uv-run.md
+++ b/lessons/tools/exit-code-127-use-uv-run.md
@@ -1,0 +1,50 @@
+---
+match:
+  keywords:
+    - "command not found exit 127"
+    - "binary not in PATH workspace"
+    - "exit code 127 in workspace"
+description: "Use uv run when child process exits with status 127 because the binary or executable is not found on PATH in workspace project"
+status: active
+---
+
+# Exit Code 127 Means Command Not Found — Use uv run in Workspace Projects
+
+## Rule
+When a bash command exits with code 127, the executable wasn't found in PATH — use `uv run` for project tools rather than assuming global availability.
+
+## Context
+When running project tools (pytest, mypy, project CLIs) in uv workspace projects. Many tools are installed only in `.venv` and aren't on `$PATH` unless explicitly activated.
+
+## Detection
+Observable signals:
+- `Exit code 127` from any bash command
+- `bash: <command>: command not found` in stderr
+- Running `pytest`, `mypy`, or project CLIs without venv activation
+- Common in uv workspace contexts where `.venv/bin` isn't on PATH
+
+## Pattern
+```bash
+# Wrong: assuming tool is on global PATH
+pytest tests/           # → Exit code 127: bash: pytest: command not found
+mypy src/               # → Exit code 127
+
+# Correct: use uv run to invoke tools in the project venv
+uv run pytest tests/
+uv run python3 script.py
+uv run mypy src/
+
+# For project-installed CLIs:
+uv run <cli-name> args
+
+# Or explicit venv path:
+.venv/bin/pytest tests/
+```
+
+## Outcome
+- Eliminates "command not found" failures in uv workspace projects
+- Consistent tool invocation regardless of shell activation state
+- Works correctly in autonomous/non-interactive sessions
+
+## Related
+- [frontend-worktree-node-modules.md](./frontend-worktree-node-modules.md) — JS worktree tooling gap

--- a/lessons/tools/frontend-worktree-node-modules.md
+++ b/lessons/tools/frontend-worktree-node-modules.md
@@ -1,0 +1,36 @@
+---
+match:
+  keywords:
+    - "worktree has no node_modules"
+    - "npx resolves a surprising tool version"
+    - "missing local binaries in worktree"
+description: "In a JS/TS frontend worktree, npx resolves a surprising tool version or npm test/lint reports missing local binaries because the worktree has no node_modules"
+status: active
+---
+
+# Frontend Worktree Node Modules
+
+## Rule
+When using a git worktree for a JS/TS frontend repo, make sure the worktree has access to the repo's real `node_modules` before running `npx`, tests, or pre-commit hooks.
+
+## Context
+This applies in repos that keep dependencies in the main checkout while the worktree is a fresh linked directory without installed packages.
+
+## Detection
+- `npx` resolves a surprising tool version in the worktree
+- pre-commit or lint fails with config-version errors that don't match the repo
+- `npm test` or `npm run lint` says local binaries are missing
+
+## Pattern
+```bash
+ln -s /path/to/base-checkout/node_modules /tmp/worktrees/repo/branch/node_modules
+```
+
+Run the command before verification or commit hooks. Remove the symlink before final status checks if you want a clean untracked tree.
+
+## Outcome
+- Hooks use the repo's actual toolchain instead of a random global/latest `npx` fallback
+- Frontend worktrees behave like the base checkout without a full reinstall
+
+## Related
+- [exit-code-127-use-uv-run.md](./exit-code-127-use-uv-run.md) — similar "tools missing in worktree" class

--- a/lessons/tools/truncated-output-false-absence.md
+++ b/lessons/tools/truncated-output-false-absence.md
@@ -1,0 +1,53 @@
+---
+match:
+  keywords:
+    - "conclude it doesn't exist"
+    - "appears untracked"
+    - "no existing copy found"
+    - "not in the list output"
+    - "head truncated the listing"
+  session_categories: [code, infrastructure, cleanup, cross-repo]
+description: "Don't conclude a file, symbol, or config is absent from head- or limit-truncated search output — confirm absence by grepping for the specific target name, not by eyeballing a truncated list"
+status: active
+---
+
+# Don't Conclude Absence From Truncated Output
+
+## Rule
+Never conclude "X doesn't exist / isn't tracked / has no copy" from output that was
+truncated by `head`, `head_limit`, or tool-output trimming. Confirm absence by
+searching for the **specific target name**, not by scanning a capped list.
+
+## Context
+Agent tool output is frequently truncated: `| head -N`, Grep tool's
+default `head_limit`, Bash stdout/stderr trimming, or tool-output trimming.
+A truncated listing produces **false negatives** — the item is present but past
+the cutoff (e.g. alphabetically beyond `head -20`).
+
+## Detection
+- About to act on "not found" / "no existing X" after a `… | head -N` command
+- Used `git ls-files '*.svc' | head` and concluded a file is untracked
+- A listing was alphabetical/sorted and your target sorts late
+- About to (re)create, re-track, or re-derive something you "confirmed" missing
+
+## Pattern
+```bash
+# ❌ False negative: target may be past the head cutoff
+git ls-files '*.service' | head -20        # target may sort late alphabetically
+# → "not listed" ≠ "not tracked"
+
+# ✅ Confirm absence by the specific name
+git ls-files '*my-service-name*'           # authoritative present/absent
+rg -l 'exact_symbol_name' path/            # not: rg ... | head, then eyeball
+git ls-files | grep -c 'target'            # count, not truncated scan
+```
+Rule of thumb: a capped list answers "what are some matches?", never
+"does this specific thing exist?". For existence, query the specific key.
+
+## Outcome
+- No wasted work re-creating/re-tracking something that already exists
+- No duplicate files committed because the canonical copy was "missing"
+- Absence claims are authoritative, not artifacts of a display limit
+
+## Related
+- [gh-body-heredoc-not-quotes.md](./gh-body-heredoc-not-quotes.md) — another "output not what you expect" class

--- a/lessons/tools/uncompilable-edit-display-trap.md
+++ b/lessons/tools/uncompilable-edit-display-trap.md
@@ -1,0 +1,55 @@
+---
+match:
+  keywords:
+    - "can't build locally"
+    - "cannot compile locally"
+    - "type-correct by inspection"
+    - "no webkit2gtk"
+    - "rely on CI for the build"
+    - "editing rust I can't compile"
+  session_categories: [cross-repo, code]
+description: "Editing compiled-language code (e.g. Rust) that can't be built locally, and claiming type-correctness by inspection — then a formatting/trait construct like {e} Display fails to compile"
+status: active
+---
+
+# Don't Overclaim Correctness for Code You Can't Compile
+
+## Rule
+When editing a compiled language you can't build locally, do not claim
+"type-correct by inspection" for trait-dependent constructs. Mirror the
+surrounding error-handling exactly, and treat CI as the real gate.
+
+## Context
+When editing Rust (or any compiled language) in an environment missing system
+libs (`gdk-3.0`, `webkit2gtk`, etc.), `cargo check`/clippy can't run. Inspection
+catches logic but not trait-resolution failures.
+
+## Detection
+- `cargo check` fails at the system-dependency stage (missing `.pc` file)
+- About to write `eprintln!("...: {e}")` / `format!("{e}")` on an error value
+- The surrounding code discards that same error: `.map_err(|_| "...".into())`,
+  or formats it with `{e:?}` (Debug) instead of `{e}` (Display)
+- Journal/PR comment says "type-correct by inspection" for non-trivial edits
+
+## Pattern
+```rust
+// Surrounding code is the type oracle. If it discards the error, the error
+// type probably does NOT implement Display:
+let p = dirs::db_path(testing).map_err(|_| "Failed to get db path")?;  // <-- signal
+
+// ❌ Display on a non-Display error type → compile error you can't catch locally
+Err(e) => { eprintln!("Error: failed to get db path: {e}"); exit(1); }
+
+// ✅ Mirror the surrounding pattern: drop the value, or use Debug if needed
+Err(_) => { eprintln!("Error: failed to get db path"); exit(1); }
+// or, when the type is known to impl Debug:  eprintln!("...: {e:?}");
+```
+
+## Outcome
+- No compile errors shipped on PRs that only CI (or a parallel session) catches
+- Honest verification claims: "fmt clean + CI is the build authority", not
+  "type-correct by inspection"
+- Error formatting stays consistent with the file's existing conventions
+
+## Related
+- [exit-code-127-use-uv-run.md](./exit-code-127-use-uv-run.md) — another CI-gate-only failure class

--- a/lessons/tools/uncompilable-edit-display-trap.md
+++ b/lessons/tools/uncompilable-edit-display-trap.md
@@ -52,4 +52,4 @@ Err(_) => { eprintln!("Error: failed to get db path"); exit(1); }
 - Error formatting stays consistent with the file's existing conventions
 
 ## Related
-- [exit-code-127-use-uv-run.md](./exit-code-127-use-uv-run.md) — another CI-gate-only failure class
+- [exit-code-127-use-uv-run.md](./exit-code-127-use-uv-run.md) — another toolchain-availability failure class


### PR DESCRIPTION
## Summary

Second batch of generic lessons upstreamed from Bob's workspace to benefit all agents forked from this template.

**Lessons added** (`lessons/tools/`):

- **`truncated-output-false-absence`** — Never conclude a file/symbol doesn't exist from `head`-truncated output; grep for the specific target name instead
- **`frontend-worktree-node-modules`** — Symlink `node_modules` from the base checkout when running tests/hooks in a JS/TS git worktree
- **`curl-script-flags`** — Always use `curl -fsSL` in scripts and health checks so HTTP 4xx/5xx errors surface as failures
- **`exit-code-127-use-uv-run`** — When a command exits 127 (not found), use `uv run` to invoke tools in the project's venv
- **`uncompilable-edit-display-trap`** — Don't claim "type-correct by inspection" for compiled-language code you can't build locally; let CI be the gate

## Generalization notes

All lessons were scrubbed of Bob-specific content:
- Removed `metadata: tags` and `target_grade` fields (not in template format)
- Generalized Context sections (replaced Bob-specific paths and repo references)
- Removed companion-doc links (companion docs don't exist in template)
- Replaced dead related-links (template-missing files) with cross-links to other lessons in this batch

## Test plan

- [x] All 5 lessons pass `validate.py` (no errors; description warning is cosmetic — matches existing merged lessons)
- [x] Pre-commit hooks pass (`check-markdown-links` verified all related-links point to existing files)
- [x] Lessons follow keyword-matching format consistent with existing `lessons/tools/` entries