### PR TITLE
feat(precommit): add check-root-structure hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,6 +28,46 @@ repos:
         args: [--ignore-missing-imports, --check-untyped-defs]
   - repo: local
     hooks:
+      - id: check-root-structure
+        name: Check root directory structure
+        description: Ensures no new top-level files or directories are added without updating the allowlist.
+        entry: python3 ./gptme-contrib/scripts/precommit/check_root_structure.py
+        language: system
+        pass_filenames: false
+        always_run: true
+        args:
+          # Files
+          - --allow=.gitattributes
+          - --allow=.github
+          - --allow=.gitignore
+          - --allow=.gitmodules
+          - --allow=.mailmap
+          - --allow=.pre-commit-config.yaml
+          - --allow=ABOUT.md
+          - --allow=AGENTS.md
+          - --allow=ARCHITECTURE.md
+          - --allow=CLAUDE.md
+          - --allow=Makefile
+          - --allow=README.md
+          - --allow=SOUL.md
+          - --allow=TASKS.md
+          - --allow=TOOLS.md
+          - --allow=WORKFLOW.md
+          # Directories
+          - --allow=bin
+          - --allow=dotfiles
+          - --allow=gptme-contrib
+          - --allow=gptme.toml
+          - --allow=journal
+          - --allow=knowledge
+          - --allow=lessons
+          - --allow=people
+          - --allow=projects
+          - --allow=scripts
+          - --allow=skills
+          - --allow=state
+          - --allow=tasks
+          - --allow=tests
       - id: check-names
         name: Check for agent-instance names
         description: Verifies that we are not accidentally using names of agents in the template, or vice versa


### PR DESCRIPTION
## What

Adds a `check-root-structure` pre-commit hook to prevent root-dir sprawl. Any new top-level entry not on the allowlist fails the check, requiring an intentional PR discussion.

## Changes

- **`.pre-commit-config.yaml`**: Add `check-root-structure` hook using the existing `./gptme-contrib/scripts/precommit/check_root_structure.py` path (pattern already used for `check-names`, `check_markdown_links`, etc.). Configured with `--allow ENTRY` args for each currently permitted root entry.

- **`gptme-contrib`** (submodule bump): Advance to `7875514e`, which adds `--allow` arg support (gptme/gptme-contrib#1479). Without this bump, `--allow` args are silently ignored and the hook would fail on every run.

## Allowlist

The `--allow` list covers all currently tracked root entries — the hook acts as a gate against future additions, not a retroactive cleanup.

Part of gptme/gptme-contrib#1445 (depends on gptme/gptme-contrib#1479).

<!-- gptme-id:v1:gai_XTALnKXYBMjf61FBeI0mFWx3Co5QAaB5Xn1jGV05XhR -->